### PR TITLE
OD-486: Menu Order should be renamed to Header Tab Order

### DIFF
--- a/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
@@ -73,7 +73,7 @@
 
   {% if not hide_field_order %}
     <div class="control-group">
-      <label for="field-order" class="control-label">{{ _('Menu Order') }}</label>
+      <label for="field-order" class="control-label">{{ _('Header Order') }}</label>
       <div class="controls">
         <select id="field-order" class="form-control" name="order">
             {% for option in [('', _('Not in Menu')), ('1','1'), ('2', '2'), ('3', '3') , ('4', '4')] %}


### PR DESCRIPTION
In CKAN Pages Extension, "Menu Order" should be renamed to "Header Order tab" for better clarity
Renamed the Menu Order to Header Order