### PR TITLE
OD 502 extend pages og stories display

### DIFF
--- a/ckanext/pages/controller.py
+++ b/ckanext/pages/controller.py
@@ -1,8 +1,10 @@
+import requests
 import ckan.plugins as p
 import ckan.lib.helpers as helpers
 from pylons import config
 
 _ = p.toolkit._
+c = p.toolkit.c
 
 class PagesController(p.toolkit.BaseController):
     controller = 'ckanext.pages.controller:PagesController'

--- a/ckanext/pages/controller.py
+++ b/ckanext/pages/controller.py
@@ -378,6 +378,11 @@ class PagesController(p.toolkit.BaseController):
         error_summary = error_summary or {}
 
         form_snippet = config.get('ckanext.pages.form', 'ckanext_pages/base_form.html')
+        og_story_list = self.story_list().get('data')
+        og_stories = [('','')]
+        for story in og_story_list:
+            og_stories.append((story.get('public_url'),story.get('title')))
+        c.og_stories = og_stories
 
         vars = {'data': data, 'errors': errors,
                 'error_summary': error_summary, 'page': page,
@@ -398,3 +403,18 @@ class PagesController(p.toolkit.BaseController):
         return """<script type='text/javascript'>
                       window.parent.CKEDITOR.tools.callFunction(%s, '%s');
                   </script>""" % (p.toolkit.request.GET['CKEditorFuncNum'], url['url'])
+
+    def _get_entity_id(self):
+        return helpers.config.get('ckanext.opengov.stories.entity_id') or h.config.get('ckanext.opengov.entity_id')
+
+    def _get_endpoint(self):
+        return helpers.config.get('ckanext.opengov.stories.backend') or h.config.get('ckanext.opengov.backend')
+
+    def _get_story_list_url(self, entity_id=None):
+        return '%s/backend/api/stories/v1/public/ckan-list?per_page=100&sort=-publishedAt&entity_id=%s'%(self._get_endpoint(), entity_id or self. _get_entity_id())
+
+    def story_list(self, entity_id=None):
+        url = self._get_story_list_url(entity_id)
+        print url
+        r = requests.get(url)
+        return r.json()

--- a/ckanext/pages/theme/public/embed_ogstories.js
+++ b/ckanext/pages/theme/public/embed_ogstories.js
@@ -1,0 +1,10 @@
+$(document).ready(function(){
+ $('#field-story').change(function(){
+   var iframeurl = $(this).val();
+   var page_title = $('#field-story option:selected').text();
+   $('#field-title').val(page_title);
+   $('#field-title').trigger('keyup');
+   var embed_markup = '<iframe height="1000px" src="'+iframeurl+'" width="100%">';
+   CKEDITOR.instances['field-content-ck'].setData(embed_markup);
+ });
+});

--- a/ckanext/pages/theme/public/resource.config
+++ b/ckanext/pages/theme/public/resource.config
@@ -14,6 +14,8 @@ main =
     vendor/datepicker/js/bootstrap-datepicker.js
     ckedit.js
     datepicker.js
+    embed_ogstories.js
+    tabs.js
     vendor/datepicker/css/datepicker.css
     ckedit.css
 

--- a/ckanext/pages/theme/public/tabs.js
+++ b/ckanext/pages/theme/public/tabs.js
@@ -1,0 +1,20 @@
+function openTab(evt, tabName) {
+   var i, tabcontent, tablinks;
+   if (tabName == "openGov") {
+       document.getElementById("story").style.display = "block";
+   }else{
+       document.getElementById("story").style.display = "none";
+   }
+   tabcontent = document.getElementsByClassName("tabcontent");
+   for (i = 0; i < tabcontent.length; i++) {
+       tabcontent[i].style.display = "none";
+   }
+   tablinks = document.getElementsByClassName("tablinks");
+   for (i = 0; i < tablinks.length; i++) {
+       tablinks[i].className = tablinks[i].className.replace(" active", "");
+   }
+   document.getElementById(tabName).style.display = "block";
+   evt.currentTarget.className += " active";
+}
+// Get the element with id="defaultOpen" and click on it
+document.getElementById("defaultOpen").click();

--- a/ckanext/pages/theme/resources/styles/pages.css
+++ b/ckanext/pages/theme/resources/styles/pages.css
@@ -15,3 +15,31 @@
 .page-list-item h3 a {
   display: block;
 }
+.tab {
+     overflow: hidden;
+     border: none;
+     background-color: #ffffff;
+     margin-bottom: 20px;
+ }
+
+ /* Style the buttons that are used to open the tab content */
+ .tab button {
+     background-color: inherit;
+     float: left;
+     border: 1px solid #ccc;
+     outline: none;
+     cursor: pointer;
+     padding: 14px 16px;
+     transition: 0.3s;
+ }
+
+ /* Change background color of buttons on hover */
+ .tab button:hover {
+     background-color: #ddd;
+ }
+
+ /* Create an active/current tablink class */
+ .tab button.active {
+     background-color: #ccc;
+ }
+

--- a/ckanext/pages/theme/resources/styles/pages.css
+++ b/ckanext/pages/theme/resources/styles/pages.css
@@ -43,3 +43,11 @@
      background-color: #ccc;
  }
 
+ /* Style the tab content */
+ .tabcontent {
+     display: none;
+ }
+.text-left .control-label, .text-left{
+  text-align: left!important;
+}
+

--- a/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
@@ -44,8 +44,33 @@
     {% set title_placeholder = _('eg. Page Title') %}
 {% endif %}
 
+<!-- Tab links -->
+    <div class="tab">
+       <button class="tablinks" onclick="openTab(event, 'addPage')" id="defaultOpen">{{ _('Page') }}</button>
+       <button class="tablinks" onclick="openTab(event, 'openGov')">{{ _('OpenGov') }}</button>
+     </div>
+
+     <!-- Tab content -->
+     <div id="addPage" class="tabcontent">
+
+     </div>
+
+     <div id="openGov" class="tabcontent">
+
+     </div>
 
 <form class="form-horizontal" method="post" action="{{ action_url }}" data-module="basic-form">
+
+  <div class="control-group" id="story">
+    <label for="field-story" class="control-label text-left">{{ _('Story') }}</label>
+    <div class="controls">
+      <select id="field-story" class="form-control" name="story">
+        {% for option in c.og_stories %}
+        <option value="{{ option[0] }}" >{{ option[1] }}</option>
+        {% endfor %}
+      </select>
+    </div>
+  </div>
 
   {{ form.input('title', id='field-title', label=_('Title'), placeholder=title_placeholder, value=data.title, error=errors.title, classes=['control-full', 'control-large'], attrs={'data-module': 'slug-preview-target'}) }}
 

--- a/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
@@ -72,13 +72,13 @@
     </div>
   </div>
 
-  {{ form.input('title', id='field-title', label=_('Title'), placeholder=title_placeholder, value=data.title, error=errors.title, classes=['control-full', 'control-large'], attrs={'data-module': 'slug-preview-target'}) }}
+  {{ form.input('title', id='field-title', label=_('Title'), placeholder=title_placeholder, value=data.title, error=errors.title, classes=['control-full', 'control-large', 'text-left'], attrs={'data-module': 'slug-preview-target'}) }}
 
   {% set domain = slug_domain|replace("http://", "")|replace("https://", "") %}
   {% set attrs = {'data-module': 'slug-preview-slug', 'data-module-prefix': domain~'/', 'data-module-placeholder': '<page>'} %}
   {{ form.prepend('name', id='field-name', label=_('URL'), prepend=slug_prefix, placeholder=_(url_placeholder), value=data.name, error=errors.name, attrs=attrs) }}
 
-  {{ form.input('publish_date', id='field-publish_date', label=_('Publish Date'), placeholder=_('2005-01-01'), value=data.publish_date, error=errors.publish_date, classes=[], attrs={'data-module': 'datepicker', 'data-date-format': 'yyyy-mm-dd'}) }}
+  {{ form.input('publish_date', id='field-publish_date', label=_('Publish Date'), placeholder=_('2005-01-01'), value=data.publish_date, error=errors.publish_date, classes=['text-left'], attrs={'data-module': 'datepicker', 'data-date-format': 'yyyy-mm-dd'}) }}
 
   {% block extra_pages_form %}
   {% endblock extra_pages_form %}
@@ -86,7 +86,7 @@
   {#{{ form.input('name', id='field-name', label=_('Name'), placeholder=_('my-name'), value=data.name, error=errors.name, classes=['control-full']) }}#}
 
   <div class="control-group">
-    <label for="field-private" class="control-label">{{ _('Visibility') }}</label>
+    <label for="field-private" class="control-label text-left">{{ _('Visibility') }}</label>
     <div class="controls">
       <select id="field-private" class="form-control" name="private">
         {% for option in [(true, _('Private')), (false, _('Public'))] %}
@@ -98,7 +98,7 @@
 
   {% if not hide_field_order %}
     <div class="control-group">
-      <label for="field-order" class="control-label">{{ _('Header Order') }}</label>
+      <label for="field-order" class="control-label text-left">{{ _('Menu Order') }}</label>
       <div class="controls">
         <select id="field-order" class="form-control" name="order">
             {% for option in [('', _('Not in Menu')), ('1','1'), ('2', '2'), ('3', '3') , ('4', '4')] %}
@@ -115,7 +115,7 @@
   {% elif editor == 'ckeditor' %}
     {% resource 'ckanext-pages/main' %}
     <div class="control-group">
-        <label for="field-content-ck" class="control-label">{{ _('Content') }}</label>
+        <label for="field-content-ck" class="control-label text-left">{{ _('Content') }}</label>
     </div>
     <textarea id="field-content-ck" name="content" placeholder="{{_('My content')}}" data-module="ckedit" style="height:400px" data-module-site_url="{{ h.dump_json(h.url('/', locale='default', qualified=true)) }}"> {{ data.content }}</textarea>
   {% else %}
@@ -140,3 +140,4 @@
   </div>
 
 </form>
+


### PR DESCRIPTION
Extending pages to display Open Gov stories select dropdown on page create/edit screen
Steps for testing the PR:
1)pull the changes from the PR in the pages extension directory
2)add the following config settings in development.in
  ckanext.opengov.stories.entity_id = 2135
  ckanext.opengov.stories.backend = https://operate.opengov.com
3)Restart ckan and go to page create screen two tab will be shown Page and Opengov Stories 
4)In opengov stories tab stories select dropdown is displayed, On select of a story its corresponding URL will get embeded in CKedittr as iframe