### PR TITLE
[OD-703] Remove descriptions from pages list

### DIFF
--- a/ckanext/pages/theme/templates_main/ckanext_pages/snippets/pages_list.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/snippets/pages_list.html
@@ -39,6 +39,7 @@
                  <small class="date"> {{ h.render_datetime(page.publish_date) }} </small>
               {% endif %}
             </h3>
+            {#
             {% if page.content %}
               {% if editor %}
               <div>
@@ -50,6 +51,7 @@
             {% else %}
               <p class="empty">{{ _('This page currently has no content') }}</p>
             {% endif %}
+            #}
         </div>
       {% else %}
         <div class="span11">
@@ -59,6 +61,7 @@
                <small class="date"> {{ h.render_datetime(page.publish_date) }} </small>
             {% endif %}
           </h3>
+          {#
           {% if page.content %}
             {% if editor %}
             <div>
@@ -70,6 +73,7 @@
           {% else %}
             <p class="empty">{{ _('This page currently has no content') }}</p>
           {% endif %}
+          #}
         </div>
       {% endif %}
       </div>


### PR DESCRIPTION
[OD-703](https://opengovinc.atlassian.net/browse/OD-703) Remove description from ckanext-pages

## Description
In the ckanext-pages extension remove the description line from the pages list (/pages). The description is actually a snippet of the first lines of the page content. An HTML page results in raw HTML code being displayed, which is not desired.

## Testing
* Install this PR
* Create a new page with HTML with an image
* Create a new page with HTML without any images
* Go to /pages and see if a description appears in any page item beneath the page title

## Approval Criteria 
Each item in the list of pages should be just the page title and an image to the left of the title if an image is available.

## Submitter Checklist
- [x] I have tested the changes locally