### PR TITLE
Revert "[OD-703] Remove descriptions from pages list"

### DIFF
--- a/ckanext/pages/theme/templates_main/ckanext_pages/snippets/pages_list.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/snippets/pages_list.html
@@ -39,7 +39,6 @@
                  <small class="date"> {{ h.render_datetime(page.publish_date) }} </small>
               {% endif %}
             </h3>
-            {#
             {% if page.content %}
               {% if editor %}
               <div>
@@ -51,7 +50,6 @@
             {% else %}
               <p class="empty">{{ _('This page currently has no content') }}</p>
             {% endif %}
-            #}
         </div>
       {% else %}
         <div class="span11">
@@ -61,7 +59,6 @@
                <small class="date"> {{ h.render_datetime(page.publish_date) }} </small>
             {% endif %}
           </h3>
-          {#
           {% if page.content %}
             {% if editor %}
             <div>
@@ -73,7 +70,6 @@
           {% else %}
             <p class="empty">{{ _('This page currently has no content') }}</p>
           {% endif %}
-          #}
         </div>
       {% endif %}
       </div>


### PR DESCRIPTION
Reverts OpenGov-OpenData/ckanext-pages#8

We have decided that this approach isn't very good. There are use cases where a line below the page title with a snippet of page content is needed.