### PR TITLE
[OD-1213] Add additional menu order

### DIFF
--- a/ckanext/pages/db.py
+++ b/ckanext/pages/db.py
@@ -35,7 +35,7 @@ def init_db(model):
             query = model.Session.query(cls).autoflush(False)
             query = query.filter_by(**kw)
             if order:
-                query = query.order_by(cls.order).filter(cls.order != '')
+                query = query.order_by(sa.cast(cls.order, sa.Integer)).filter(cls.order != '')
             elif order_publish_date:
                 query = query.order_by(cls.publish_date.desc()).filter(cls.publish_date != None)
             else:

--- a/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
@@ -76,7 +76,7 @@
       <label for="field-order" class="control-label">{{ _('Header Order') }}</label>
       <div class="controls">
         <select id="field-order" class="form-control" name="order">
-            {% for option in [('', _('Not in Menu')), ('1','1'), ('2', '2'), ('3', '3') , ('4', '4') , ('5','5') , ('6','6') , ('7','7') , ('8','8') , ('9','9'), ('10','10') , ('11','11') ,('12','12') , ('13','13') ,('14','14') ,('15','15') ,('16','16'),('17','17') , ('18','18'), ('19','19'), ('20','20'),('21','21')] %}
+            {% for option in [('', _('Not in Menu')), ('1','1'), ('2', '2'), ('3', '3') , ('4', '4')] %}
           <option value="{{ option[0] }}" {% if option[0] == data.order %}selected="selected"{% endif %}>{{ option[1] }}</option>
           {% endfor %}
         </select>

--- a/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/base_form.html
@@ -76,7 +76,7 @@
       <label for="field-order" class="control-label">{{ _('Header Order') }}</label>
       <div class="controls">
         <select id="field-order" class="form-control" name="order">
-            {% for option in [('', _('Not in Menu')), ('1','1'), ('2', '2'), ('3', '3') , ('4', '4')] %}
+            {% for option in [('', _('Not in Menu')), ('1','1'), ('2', '2'), ('3', '3') , ('4', '4') , ('5','5') , ('6','6') , ('7','7') , ('8','8') , ('9','9'), ('10','10') , ('11','11') ,('12','12') , ('13','13') ,('14','14') ,('15','15') ,('16','16'),('17','17') , ('18','18'), ('19','19'), ('20','20'),('21','21')] %}
           <option value="{{ option[0] }}" {% if option[0] == data.order %}selected="selected"{% endif %}>{{ option[1] }}</option>
           {% endfor %}
         </select>


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [TICKET](https://opengovinc.atlassian.net/browse/OD-1213)

## Description
<!--- Describe these changes in detail --->
1.Allow drop down menu to have more items, increased from 4 to 21. (this will require ckanext-opengov extension enabled to overwrite base_form.html) see PR: https://github.com/OpenGov-OpenData/ckanext-opengov/pull/24
2.And sort the order number by integer instead of by string.

## Test Procedure
<!--- List the steps involved to test the changes --->
1.Enable the pages extension and checkout this PR branch
2.Test it with idaho theme from og_theme master or og_theme idaho branch
3.Add pages whose order number are like 1,2,5,10,20 , make sure the drop down menu shows the pages in ascending order.

## Approval Criteria 
<!--- Describe the expected results of testing --->

## Submitter Checklist
- [ ] The code looks good to me (LGTM)
- [ ] I have tested the changes locally
- [ ] The new changes does not affect web accessibility
