### PR TITLE
[PA-508]fix description from html rendering

### DIFF
--- a/ckanext/pages/plugin.py
+++ b/ckanext/pages/plugin.py
@@ -97,8 +97,11 @@ def get_plus_icon():
         return 'plus-square'
     return 'plus-sign-alt'
 
-def remove_elements(page_content):
-    return re.sub(r'(<style.+style>)',r'',page_content)
+def clean_content(page_content):
+    content_cleaned = page_content
+    content_cleaned = re.sub(r'(<style.+style>)', r'', content_cleaned)
+    content_cleaned = re.sub(r'(<script.+script>)', r'', content_cleaned)
+    return content_cleaned
 
 class PagesPlugin(PagesPluginBase):
     p.implements(p.IConfigurer, inherit=True)
@@ -136,7 +139,7 @@ class PagesPlugin(PagesPluginBase):
             'get_wysiwyg_editor': get_wysiwyg_editor,
             'get_recent_blog_posts': get_recent_blog_posts,
             'pages_get_plus_icon': get_plus_icon,
-            'pages_reomve_elements': remove_elements
+            'pages_clean_content': clean_content
         }
 
     def after_map(self, map):

--- a/ckanext/pages/plugin.py
+++ b/ckanext/pages/plugin.py
@@ -9,7 +9,8 @@ import ckan.plugins as p
 import ckan.lib.helpers as h
 import actions
 import auth
-
+import re
+from jinja2 import evalcontextfilter
 if toolkit.check_ckan_version(min_version='2.5'):
     from ckan.lib.plugins import DefaultTranslation
 
@@ -96,6 +97,8 @@ def get_plus_icon():
         return 'plus-square'
     return 'plus-sign-alt'
 
+def remove_elements(page_content):
+    return re.sub(r'(<style.+style>)',r'',page_content)
 
 class PagesPlugin(PagesPluginBase):
     p.implements(p.IConfigurer, inherit=True)
@@ -132,7 +135,8 @@ class PagesPlugin(PagesPluginBase):
             'render_content': render_content,
             'get_wysiwyg_editor': get_wysiwyg_editor,
             'get_recent_blog_posts': get_recent_blog_posts,
-            'pages_get_plus_icon': get_plus_icon
+            'pages_get_plus_icon': get_plus_icon,
+            'pages_reomve_elements': remove_elements
         }
 
     def after_map(self, map):

--- a/ckanext/pages/plugin.py
+++ b/ckanext/pages/plugin.py
@@ -99,8 +99,9 @@ def get_plus_icon():
 
 def clean_content(page_content):
     content_cleaned = page_content.replace('\n', ' ')
-    content_cleaned = re.sub(r'(<style.+style>)', r'', content_cleaned)
-    content_cleaned = re.sub(r'(<script.+script>)', r'', content_cleaned)
+    tags = [r'(<style.+style>)', r'(<script.+script>)', r'(<noscript.+noscript>)']
+    for tag in tags:
+        content_cleaned = re.sub(tag, r'', content_cleaned)
     return content_cleaned
 
 class PagesPlugin(PagesPluginBase):

--- a/ckanext/pages/plugin.py
+++ b/ckanext/pages/plugin.py
@@ -10,7 +10,7 @@ import ckan.lib.helpers as h
 import actions
 import auth
 import re
-from jinja2 import evalcontextfilter
+
 if toolkit.check_ckan_version(min_version='2.5'):
     from ckan.lib.plugins import DefaultTranslation
 

--- a/ckanext/pages/plugin.py
+++ b/ckanext/pages/plugin.py
@@ -98,7 +98,7 @@ def get_plus_icon():
     return 'plus-sign-alt'
 
 def clean_content(page_content):
-    content_cleaned = page_content
+    content_cleaned = page_content.replace('\n', ' ')
     content_cleaned = re.sub(r'(<style.+style>)', r'', content_cleaned)
     content_cleaned = re.sub(r'(<script.+script>)', r'', content_cleaned)
     return content_cleaned

--- a/ckanext/pages/theme/templates_main/ckanext_pages/snippets/pages_list.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/snippets/pages_list.html
@@ -62,7 +62,7 @@
           {% if page.content %}
             {% if editor %}
             <div>
-              {{page.content|striptags|truncate}}
+              {{h.pages_reomve_elements(page.content)|striptags|truncate}}
             </div>
             {% else %}
               {{ h.markdown_extract(page.content) }}

--- a/ckanext/pages/theme/templates_main/ckanext_pages/snippets/pages_list.html
+++ b/ckanext/pages/theme/templates_main/ckanext_pages/snippets/pages_list.html
@@ -42,7 +42,7 @@
             {% if page.content %}
               {% if editor %}
               <div>
-                {{page.content|striptags|truncate}}
+                {{h.pages_clean_content(page.content)|striptags|truncate}}
               </div>
               {% else %}
                 {{ h.markdown_extract(page.content) }}
@@ -62,7 +62,7 @@
           {% if page.content %}
             {% if editor %}
             <div>
-              {{h.pages_reomve_elements(page.content)|striptags|truncate}}
+              {{h.pages_clean_content(page.content)|striptags|truncate}}
             </div>
             {% else %}
               {{ h.markdown_extract(page.content) }}


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [TICKET](https://opengovinc.atlassian.net/browse/PA-508)

## Description
<!--- Describe these changes in detail --->
Added a helper function to clean up html tags like <script> and <style>, whose content is not supposed to show up in page description.

## Test Procedure
<!--- List the steps involved to test the changes --->
1.python setup.py develop
2.enable `pages` plugin
3.When create a new page, in the 'content' box. click on 'source' on the right of the menu bar, then add the following code:
```
<script>var a=1; </script>
<style type="text/css">.finance-block="" .module-content="" min-height:="" text-align:=""
</style>
<p><strong>Hello World!</strong></p>

```

4. go to http://localhost/pages
the description for  the page has only "Hello world"

## Approval Criteria 
<!--- Describe the expected results of testing --->
-no extra content shows up in description

## Submitter Checklist
- [ ] The code looks good to me (LGTM)
- [ ] I have tested the changes locally
- [ ] The new changes does not affect web accessibility
